### PR TITLE
Improve the help message

### DIFF
--- a/libexec/tfenv-help
+++ b/libexec/tfenv-help
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
 set -e
 [ -n "$TFENV_DEBUG" ] && set -x
-echo "usage: tfenv (install|use|list|list-remote) <options>"
+echo "Usage: tfenv <command> [<options>]
+
+Commands:
+   install       Install a specific version of Terraform
+   use           Switch a version to use
+   list          List all installed versions
+   list-remote   List all installable versions
+"


### PR DESCRIPTION
I improved the help message:
```
% tfenv
tfenv 0.3.0
Usage: tfenv <command> [<options>]

Commands:
   install       Install a specific version of Terraform
   use           Switch a version to use
   list          List all installed versions
   list-remote   List all installable versions
   
```