### PR TITLE
Provide a regex filter to "latest", and provide "latest" with filter to "tfenv use"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-[![Build Status](https://travis-ci.org/kamatama41/tfenv.svg?branch=master)](https://travis-ci.org/kamatama41/tfenv)
-
 # tfenv
 [Terraform](https://www.terraform.io/) version manager inspired by [rbenv](https://github.com/rbenv/rbenv)
+This version forked from [kamatama41](https://github.com/kamatama41/tfenv)
 
 ## Support
 Currently tfenv supports the following OSes
@@ -13,7 +12,7 @@ Currently tfenv supports the following OSes
 1. Check out tfenv into any path (here is `${HOME}/.tfenv`)
 
   ```sh
-  $ git clone https://github.com/kamatama41/tfenv.git ~/.tfenv
+  $ git clone https://github.com/cartest/tfenv.git ~/.tfenv
   ```
 
 2. Add `~/.tfenv/bin` to your `$PATH` any way you like
@@ -32,17 +31,23 @@ Currently tfenv supports the following OSes
 ### tfenv install
 Install a specific version of Terraform  
 `latest` is a syntax to install latest version
+`latest:<regex>` is a syntax to install latest version matching regex (used by grep -e)
 ```sh
 $ tfenv install 0.7.0
 $ tfenv install latest
+$ tfenv install latest:^0.8
 ```
 
 If you use [.terraform-version](#terraform-version), `tfenv install` (no argument) will install the version written in it.
 
 ### tfenv use
 Switch a version to use
+`latest` is a syntax to use the latest installed version
+`latest:<regex>` is a syntax to use latest installed version matching regex (used by grep -e)
 ```sh
 $ tfenv use 0.7.0
+$ tfenv use latest
+$ tfenv use latest:^0.8
 ```
 
 ### tfenv list
@@ -103,6 +108,7 @@ $ rm -rf /some/path/to/tfenv
 ```
 
 ## LICENSE
-- [tfenv itself](https://github.com/kamatama41/tfenv/blob/master/LICENSE)
+- [tfenv original](https://github.com/kamatama41/tfenv/blob/master/LICENSE)
+- [this tfenv fork](https://github.com/cartest/tfenv/blob/master/LICENSE)
 - [rbenv](https://github.com/rbenv/rbenv/blob/master/LICENSE)
   - tfenv partially uses rbenv's source code

--- a/libexec/tfenv---version
+++ b/libexec/tfenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "$TFENV_DEBUG" ] && set -x
 
-version="0.3.4"
+version="0.4.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q tfenv; then

--- a/libexec/tfenv-help
+++ b/libexec/tfenv-help
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 [ -n "$TFENV_DEBUG" ] && set -x
 echo "Usage: tfenv <command> [<options>]
 

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -31,7 +31,7 @@ if [ -z "${version}" ]; then
   fi
 fi
 
-[ -z "${version}" ] || error_and_die "Version is not specified"
+[ -n "${version}" ] || error_and_die "Version is not specified"
 
 dst_path="${TFENV_ROOT}/versions/${version}"
 if [ -f ${dst_path}/terraform ];then
@@ -54,7 +54,7 @@ tarball_name="terraform_${version}_${os}.zip"
 tarball_url="https://releases.hashicorp.com/terraform/${version}/${tarball_name}"
 echo "Installing Terraform v${version}"
 echo "Downloading release tarball from ${tarball_url}"
-curl -f -o /tmp/${tarball_name} "${tarball_url}" || error_and_die "Tarball download failed"
+curl --tlsv1.2 -f -o /tmp/${tarball_name} "${tarball_url}" || error_and_die "Tarball download failed"
 mkdir -p ${dst_path} || error_and_die "Failed to make directory ${dst_path}"
 unzip /tmp/${tarball_name} -d ${dst_path} || error_and_die "Tarball unzip failed"
 echo -e "\033[0;32mInstallation of terraform v${version} successful\033[0;39m"

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
-set -e
+
+function error_and_die() {
+  echo -e "${1}" >&2
+  exit 1
+}
+
 [ -n "$TFENV_DEBUG" ] && set -x
 
-if [ $# -gt 1 ];then
-  echo "usage: tfenv install [<version>]" 1>&2
-  exit 1
+[ $# -gt 1 ] && error_and_die "usage: tfenv install [<version>]"
+
+declare version regex
+if [[ "${1}" =~ ^latest\:.*$ ]]; then
+  version="${1%%\:*}"
+  regex="${1##*\:}"
+else
+  version="${1}"
 fi
 
-version="${1}"
-if [ "${version}" == "latest" ];then
-  version=$(tfenv-list-remote | head -n 1)
+if [ ${version} == "latest" ]; then
+  version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)"
+  [ -n "${version}" ] || error_and_die "No matching version found in remote"
+elif [ -z "$(tfenv-list-remote | grep "${version}")" ]; then
+  error_and_die "Terraform version '${version}' doesn't exist in remote, please confirm version name."
 fi
 
 if [ -z "${version}" ]; then
@@ -19,20 +31,12 @@ if [ -z "${version}" ]; then
   fi
 fi
 
-if [ -z "${version}" ];then
-  echo "version is not specified" 1>&2
-  exit 1
-fi
+[ -z "${version}" ] || error_and_die "Version is not specified"
 
-dst_path=${TFENV_ROOT}/versions/${version}
+dst_path="${TFENV_ROOT}/versions/${version}"
 if [ -f ${dst_path}/terraform ];then
-  echo "already installed ${version}"
-  exit
-fi
-
-if [ -z "$(tfenv-list-remote | grep "${version}")" ];then
-  echo "'${version}' doesn't exist in remote, please confirm version name."
-  exit 1
+  echo "Terraform v${version} is already installed"
+  exit 0
 fi
 
 case "$(uname -s)" in
@@ -46,11 +50,11 @@ MINGW64* )
   os="linux_amd64"
 esac
 
-archive_name="terraform_${version}_${os}.zip"
-archive_url="https://releases.hashicorp.com/terraform/${version}/${archive_name}"
-echo "install Terraform ${version}"
-echo "get archive from ${archive_url}"
-curl -f -o /tmp/${archive_name} "${archive_url}"
-mkdir -p ${dst_path}
-unzip /tmp/${archive_name} -d ${dst_path}
-echo -e "\033[0;32mthe installation ${version} was successful!!!\033[0;39m"
+tarball_name="terraform_${version}_${os}.zip"
+tarball_url="https://releases.hashicorp.com/terraform/${version}/${tarball_name}"
+echo "Installing Terraform v${version}"
+echo "Downloading release tarball from ${tarball_url}"
+curl -f -o /tmp/${tarball_name} "${tarball_url}" || error_and_die "Tarball download failed"
+mkdir -p ${dst_path} || error_and_die "Failed to make directory ${dst_path}"
+unzip /tmp/${tarball_name} -d ${dst_path} || error_and_die "Tarball unzip failed"
+echo -e "\033[0;32mInstallation of terraform v${version} successful\033[0;39m"

--- a/libexec/tfenv-list
+++ b/libexec/tfenv-list
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
-set -e
+
+function error_and_die() {
+  echo -e "${1}" >&2
+  exit 1
+}
+
 [ -n "$TFENV_DEBUG" ] && set -x
 
-if [ $# -ne 0 ];then
-  echo "usage: tfenv list" 1>&2
-  exit 1
-fi
+[ $# -ne 0 ] \
+  && error_and_die "usage: tfenv list"
 
+[ -d "${TFENV_ROOT}/versions" ] \
+  || error_and_die "No versions available. Please install one with: tfenv install"
+
+set -e
 ls -1 "${TFENV_ROOT}/versions" | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3

--- a/libexec/tfenv-list-remote
+++ b/libexec/tfenv-list-remote
@@ -7,4 +7,4 @@ if [ $# -ne 0 ];then
   exit 1
 fi
 
-curl -sf https://releases.hashicorp.com/terraform/ | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)?" | uniq
+curl --tlsv1.2 -sf https://releases.hashicorp.com/terraform/ | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)?" | uniq

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -27,7 +27,7 @@ fi
     | head -n 1
   )"
 
-[ -z "${version}" ] || error_and_die "Version not specified or not found"
+[ -n "${version}" ] || error_and_die "Version not specified or not found"
 
 target_path=${TFENV_ROOT}/versions/${version}
 [ -f ${target_path}/terraform ] \

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -1,23 +1,37 @@
 #!/usr/bin/env bash
-set -e
+
+function error_and_die() {
+  echo -e "${1}" >&2
+  exit 1
+}
+
 [ -n "$TFENV_DEBUG" ] && set -x
 
-if [ $# -ne 1 ];then
-  echo "usage: tfenv use <version>" 1>&2
-  exit 1
+[ $# -ne 1 ] && error_and_die "usage: tfenv use <version>"
+
+declare version
+if [[ "${1}" =~ ^latest\:.*$ ]]; then
+  version="${1%%\:*}"
+  regex="${1##*\:}"
+else
+  version="${1}"
 fi
 
-version="${1}"
-if [ -z "${version}" ];then
-  echo "version is not specified" 1>&2
-  exit 1
-fi
+[ -d "${TFENV_ROOT}/versions" ] \
+  || error_and_die "No versions of terraform installed. Please install one with: tfenv install"
+
+[ "${version}" == "latest" ] \
+  && version="$(\ls "${TFENV_ROOT}/versions" \
+    | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
+    | grep -e "${regex}" \
+    | head -n 1
+  )"
+
+[ -z "${version}" ] || error_and_die "Version not specified or not found"
 
 target_path=${TFENV_ROOT}/versions/${version}
-if [ ! -f ${target_path}/terraform ];then
-  echo "${version} is not installed" 1>&2
-  exit 1
-fi
+[ -f ${target_path}/terraform ] \
+  || error_and_die "Terraform version ${version} is not installed"
 
 echo "${version}" > "${TFENV_ROOT}/version"
-terraform --version
+terraform --version || error_and_die "'terraform --version' failed. Something is seriously wrong"


### PR DESCRIPTION
I've been a bit savage with the bash code for my own standards, changing some naming, removing set -e where appropriate, replacing with error trapping. Standardising the error_and_die function etc, and rewording some of the errors, so you probably won't want to accept this PR as-is; however you might be interested in the way I have included a regex filter for "latest" and an option for a filtered "latest" for use to allow you to be more specific about the versions you want to match.

e.g. if you want to not upgrade to v0.9 yet:

```
tfenv install latest:^0.8
tfenv use latest:^0.8
```