### PR TITLE
Additional development of latest. Bash standards. Revert to upstream README.md. Add CHANGELOG.md. Develop Test Suite.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## 0.4.1 (March 8, 2017)
+
+ * Update error_and_die functions to better report their source location
+ * libexec/tfenv-version-name: Respect latest & latest:<regex> syntax in .terraform-version
+
+## 0.4.0 (March 6, 2017)
+
+ * Add capability to specify latest or latest:<regex> in the `use` and `install` actions.
+ * Add error_and_die functions to standardise error output
+ * Specify --tlsv1.2 to curl requests to remote repo. TLSv1.2 required; supported by but not auto-selected by older NSS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## 0.4.1 (March 8, 2017)
 
  * Update error_and_die functions to better report their source location
- * libexec/tfenv-version-name: Respect latest & latest:<regex> syntax in .terraform-version
+ * libexec/tfenv-version-name: Respect `latest` & `latest:<regex>` syntax in .terraform-version
  * Extension and development of test suite standards
 
 ## 0.4.0 (March 6, 2017)
 
- * Add capability to specify latest or latest:<regex> in the `use` and `install` actions.
+ * Add capability to specify `latest` or `latest:<regex>` in the `use` and `install` actions.
  * Add error_and_die functions to standardise error output
  * Specify --tlsv1.2 to curl requests to remote repo. TLSv1.2 required; supported by but not auto-selected by older NSS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  * Update error_and_die functions to better report their source location
  * libexec/tfenv-version-name: Respect latest & latest:<regex> syntax in .terraform-version
+ * Extension and development of test suite standards
 
 ## 0.4.0 (March 6, 2017)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+[![Build Status](https://travis-ci.org/kamatama41/tfenv.svg?branch=master)](https://travis-ci.org/kamatama41/tfenv)
+
 # tfenv
 [Terraform](https://www.terraform.io/) version manager inspired by [rbenv](https://github.com/rbenv/rbenv)
-This version forked from [kamatama41](https://github.com/kamatama41/tfenv)
 
 ## Support
 Currently tfenv supports the following OSes
@@ -12,7 +13,7 @@ Currently tfenv supports the following OSes
 1. Check out tfenv into any path (here is `${HOME}/.tfenv`)
 
   ```sh
-  $ git clone https://github.com/cartest/tfenv.git ~/.tfenv
+  $ git clone https://github.com/kamatama41/tfenv.git ~/.tfenv
   ```
 
 2. Add `~/.tfenv/bin` to your `$PATH` any way you like
@@ -54,6 +55,9 @@ $ tfenv use latest:^0.8
 List installed versions
 ```sh
 % tfenv list
+0.9.0-beta2
+0.8.8
+0.8.4
 0.7.0
 0.7.0-rc4
 0.6.16
@@ -65,20 +69,29 @@ List installed versions
 List installable versions
 ```sh
 % tfenv list-remote
-0.7.0
-0.7.0-rc4
-0.7.0-rc3
-0.7.0-rc2
-0.7.0-rc1
-0.6.16
-0.6.15
-0.6.14
-0.6.13
+0.9.0-beta2
+0.9.0-beta1
+0.8.8
+0.8.7
+0.8.6
+0.8.5
+0.8.4
+0.8.3
+0.8.2
+0.8.1
+0.8.0
+0.8.0-rc3
+0.8.0-rc2
+0.8.0-rc1
+0.8.0-beta2
+0.8.0-beta1
+0.7.13
+0.7.12
 ...
 ```
 
 ## .terraform-version
-If you put `.terraform-version` file on your project root, tfenv detects it and use the version written in it.
+If you put `.terraform-version` file on your project root, tfenv detects it and use the version written in it. If the version is `latest` or `latest:<regex>`, the latest matching version currently installed will be selected.
 
 ```sh
 $ cat .terraform-version
@@ -95,6 +108,10 @@ $ echo 0.7.3 > .terraform-version
 $ terraform --version
 Terraform v0.7.3
 
+$ echo latest:^0.8 > .terraform-version
+
+$ terraform --version
+Terraform v0.8.8
 ```
 
 ## Upgrading
@@ -108,7 +125,7 @@ $ rm -rf /some/path/to/tfenv
 ```
 
 ## LICENSE
-- [tfenv original](https://github.com/kamatama41/tfenv/blob/master/LICENSE)
-- [this tfenv fork](https://github.com/cartest/tfenv/blob/master/LICENSE)
+- [tfenv itself](https://github.com/kamatama41/tfenv/blob/master/LICENSE)
 - [rbenv](https://github.com/rbenv/rbenv/blob/master/LICENSE)
   - tfenv partially uses rbenv's source code
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-[![Build Status](https://travis-ci.org/kamatama41/tfenv.svg?branch=master)](https://travis-ci.org/kamatama41/tfenv)
-
 # tfenv
 [Terraform](https://www.terraform.io/) version manager inspired by [rbenv](https://github.com/rbenv/rbenv)
+This version forked from [kamatama41](https://github.com/kamatama41/tfenv)
 
 ## Support
 Currently tfenv supports the following OSes
@@ -13,7 +12,7 @@ Currently tfenv supports the following OSes
 1. Check out tfenv into any path (here is `${HOME}/.tfenv`)
 
   ```sh
-  $ git clone https://github.com/kamatama41/tfenv.git ~/.tfenv
+  $ git clone https://github.com/cartest/tfenv.git ~/.tfenv
   ```
 
 2. Add `~/.tfenv/bin` to your `$PATH` any way you like
@@ -32,17 +31,23 @@ Currently tfenv supports the following OSes
 ### tfenv install
 Install a specific version of Terraform  
 `latest` is a syntax to install latest version
+`latest:<regex>` is a syntax to install latest version matching regex (used by grep -e)
 ```sh
 $ tfenv install 0.7.0
 $ tfenv install latest
+$ tfenv install latest:^0.8
 ```
 
 If you use [.terraform-version](#terraform-version), `tfenv install` (no argument) will install the version written in it.
 
 ### tfenv use
 Switch a version to use
+`latest` is a syntax to use the latest installed version
+`latest:<regex>` is a syntax to use latest installed version matching regex (used by grep -e)
 ```sh
 $ tfenv use 0.7.0
+$ tfenv use latest
+$ tfenv use latest:^0.8
 ```
 
 ### tfenv list
@@ -103,6 +108,7 @@ $ rm -rf /some/path/to/tfenv
 ```
 
 ## LICENSE
-- [tfenv itself](https://github.com/kamatama41/tfenv/blob/master/LICENSE)
+- [tfenv original](https://github.com/kamatama41/tfenv/blob/master/LICENSE)
+- [this tfenv fork](https://github.com/cartest/tfenv/blob/master/LICENSE)
 - [rbenv](https://github.com/rbenv/rbenv/blob/master/LICENSE)
   - tfenv partially uses rbenv's source code

--- a/libexec/tfenv---version
+++ b/libexec/tfenv---version
@@ -10,9 +10,9 @@
 # tagged.
 
 set -e
-[ -n "$TFENV_DEBUG" ] && set -x
+[ -n "${TFENV_DEBUG}" ] && set -x
 
-version="0.4.0"
+version="0.4.1"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q tfenv; then

--- a/libexec/tfenv-exec
+++ b/libexec/tfenv-exec
@@ -14,10 +14,9 @@
 #   PATH="$TFENV_ROOT/versions/0.7.0/bin:$PATH" terraform plan
 
 set -e
-[ -n "$TFENV_DEBUG" ] && set -x
+[ -n "${TFENV_DEBUG}" ] && set -x
 
-TFENV_VERSION="$(tfenv-version-name)"
-export TFENV_VERSION
+export TFENV_VERSION="$(tfenv-version-name)"
 TF_BIN_PATH="${TFENV_ROOT}/versions/${TFENV_VERSION}/terraform"
 export PATH="${TF_BIN_PATH}:${PATH}"
-"$TF_BIN_PATH" "$@"
+"${TF_BIN_PATH}" "${@}"

--- a/libexec/tfenv-help
+++ b/libexec/tfenv-help
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-[ -n "$TFENV_DEBUG" ] && set -x
+
+[ -n "${TFENV_DEBUG}" ] && set -x
+
 echo "Usage: tfenv <command> [<options>]
 
 Commands:

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function error_and_die() {
-  echo -e "${1}" >&2
+  echo -e "tfenv: ${0}: ${1}" >&2
   exit 1
 }
 

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -5,9 +5,9 @@ function error_and_die() {
   exit 1
 }
 
-[ -n "$TFENV_DEBUG" ] && set -x
+[ -n "${TFENV_DEBUG}" ] && set -x
 
-[ $# -gt 1 ] && error_and_die "usage: tfenv install [<version>]"
+[ ${#} -gt 1 ] && error_and_die "usage: tfenv install [<version>]"
 
 declare version regex
 if [[ "${1}" =~ ^latest\:.*$ ]]; then
@@ -17,7 +17,7 @@ else
   version="${1}"
 fi
 
-if [ ${version} == "latest" ]; then
+if [ "${version}" == "latest" ]; then
   version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)"
   [ -n "${version}" ] || error_and_die "No matching version found in remote"
 elif [ -z "$(tfenv-list-remote | grep "${version}")" ]; then

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -9,29 +9,31 @@ function error_and_die() {
 
 [ ${#} -gt 1 ] && error_and_die "usage: tfenv install [<version>]"
 
-declare version regex
-if [[ "${1}" =~ ^latest\:.*$ ]]; then
-  version="${1%%\:*}"
-  regex="${1##*\:}"
-else
-  version="${1}"
-fi
+declare version_requested version regex
 
-if [ "${version}" == "latest" ]; then
-  version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)"
-  [ -n "${version}" ] || error_and_die "No matching version found in remote"
-elif [ -z "$(tfenv-list-remote | grep "${version}")" ]; then
-  error_and_die "Terraform version '${version}' doesn't exist in remote, please confirm version name."
-fi
-
-if [ -z "${version}" ]; then
+if [ -z "${1}" ]; then
   version_file="$(tfenv-version-file)"
   if [ "${version_file}" != "${TFENV_ROOT}/version" ];then
-    version="$(cat ${version_file} || true)"
+    version_requested="$(cat ${version_file} || true)"
   fi
+else
+  version_requested="${1}"
+fi
+
+if [[ "${version_requested}" =~ ^latest\:.*$ ]]; then
+  version="${version_requested%%\:*}"
+  regex="${version_requested##*\:}"
+elif [[ "${version_requested}" =~ ^latest$ ]]; then
+  version="${version_requested}"
+  regex=""
+else
+  version="${version_requested}"
+  regex="${version_requested}"
 fi
 
 [ -n "${version}" ] || error_and_die "Version is not specified"
+version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)"
+[ -n "${version}" ] || error_and_die "No versions matching '${1}' found in remote"
 
 dst_path="${TFENV_ROOT}/versions/${version}"
 if [ -f ${dst_path}/terraform ];then

--- a/libexec/tfenv-list
+++ b/libexec/tfenv-list
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function error_and_die() {
-  echo -e "${1}" >&2
+  echo -e "tfenv: ${0}: ${1}" >&2
   exit 1
 }
 

--- a/libexec/tfenv-list
+++ b/libexec/tfenv-list
@@ -5,13 +5,15 @@ function error_and_die() {
   exit 1
 }
 
-[ -n "$TFENV_DEBUG" ] && set -x
+[ -n "${TFENV_DEBUG}" ] && set -x
 
-[ $# -ne 0 ] \
+[ ${#} -ne 0 ] \
   && error_and_die "usage: tfenv list"
 
 [ -d "${TFENV_ROOT}/versions" ] \
   || error_and_die "No versions available. Please install one with: tfenv install"
 
-set -e
+[[ -x "${TFENV_ROOT}/versions" && -r "${TFENV_ROOT}/versions" ]] \
+  || error_and_die "tfenv versions directory is inaccessible!"
+
 ls -1 "${TFENV_ROOT}/versions" | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3

--- a/libexec/tfenv-list-remote
+++ b/libexec/tfenv-list-remote
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
-[ -n "$TFENV_DEBUG" ] && set -x
+[ -n "${TFENV_DEBUG}" ] && set -x
 
-if [ $# -ne 0 ];then
+if [ ${#} -ne 0 ];then
   echo "usage: tfenv list-remote" 1>&2
   exit 1
 fi

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function error_and_die() {
-  echo -e "${1}" >&2
+  echo -e "tfenv: ${0}: ${1}" >&2
   exit 1
 }
 

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -5,9 +5,9 @@ function error_and_die() {
   exit 1
 }
 
-[ -n "$TFENV_DEBUG" ] && set -x
+[ -n "${TFENV_DEBUG}" ] && set -x
 
-[ $# -ne 1 ] && error_and_die "usage: tfenv use <version>"
+[ ${#} -ne 1 ] && error_and_die "usage: tfenv use <version>"
 
 declare version
 if [[ "${1}" =~ ^latest\:.*$ ]]; then
@@ -27,11 +27,13 @@ fi
     | head -n 1
   )"
 
-[ -n "${version}" ] || error_and_die "Version not specified or not found"
+[ -n "${version}" ] || error_and_die "No installed versions of terraform matched '${1}'"
 
 target_path=${TFENV_ROOT}/versions/${version}
 [ -f ${target_path}/terraform ] \
-  || error_and_die "Terraform version ${version} is not installed"
+  || error_and_die "Version directory for ${version} is present, but the terraform binary is not! Manual intervention required."
+[ -x ${target_path}/terraform ] \
+  || error_and_die "Version directory for ${version} is present, but the terraform binary is not executable! Manual intervention required. "
 
 echo "${version}" > "${TFENV_ROOT}/version"
 terraform --version || error_and_die "'terraform --version' failed. Something is seriously wrong"

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -9,23 +9,29 @@ function error_and_die() {
 
 [ ${#} -ne 1 ] && error_and_die "usage: tfenv use <version>"
 
-declare version
-if [[ "${1}" =~ ^latest\:.*$ ]]; then
-  version="${1%%\:*}"
-  regex="${1##*\:}"
+declare version_requested version regex
+
+version_requested="${1}"
+
+if [[ "${version_requested}" =~ ^latest\:.*$ ]]; then
+  version="${version_requested%%\:*}"
+  regex="${version_requested##*\:}"
+elif [[ "${version_requested}" =~ ^latest$ ]]; then
+  version="${version_requested}"
+  regex=""
 else
-  version="${1}"
+  version="${version_requested}"
+  regex="${version_requested}"
 fi
 
 [ -d "${TFENV_ROOT}/versions" ] \
   || error_and_die "No versions of terraform installed. Please install one with: tfenv install"
 
-[ "${version}" == "latest" ] \
-  && version="$(\ls "${TFENV_ROOT}/versions" \
-    | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
-    | grep -e "${regex}" \
-    | head -n 1
-  )"
+version="$(\ls "${TFENV_ROOT}/versions" \
+  | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
+  | grep -e "${regex}" \
+  | head -n 1
+)"
 
 [ -n "${version}" ] || error_and_die "No installed versions of terraform matched '${1}'"
 

--- a/libexec/tfenv-version-file
+++ b/libexec/tfenv-version-file
@@ -2,19 +2,19 @@
 # Usage: tfenv version-file
 # Summary: Detect the file that sets the current tfenv version
 set -e
-[ -n "$TFENV_DEBUG" ] && set -x
+[ -n "${TFENV_DEBUG}" ] && set -x
 
 find_local_version_file() {
-  local root="$1"
-  while ! [[ "$root" =~ ^//[^/]*$ ]]; do
+  local root="${1}"
+  while ! [[ "${root}" =~ ^//[^/]*$ ]]; do
     if [ -e "${root}/.terraform-version" ]; then
       echo "${root}/.terraform-version"
       return 0
     fi
-    [ -n "$root" ] || break
+    [ -n "${root}" ] || break
     root="${root%/*}"
   done
   return 1
 }
 
-find_local_version_file "$TFENV_DIR" || echo "${TFENV_ROOT}/version"
+find_local_version_file "${TFENV_DIR}" || echo "${TFENV_ROOT}/version"

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -7,13 +7,13 @@ function error_and_die() {
   exit 1
 }
 
-[ -n "$TFENV_DEBUG" ] && set -x
+[ -n "${TFENV_DEBUG}" ] && set -x
 
 [ -d "${TFENV_ROOT}/versions" ] \
   || error_and_die "No versions of terraform installed. Please install one with: tfenv install"
 
 TFENV_VERSION_FILE="$(tfenv-version-file)"
-TFENV_VERSION="$(cat "$TFENV_VERSION_FILE" || true)"
+TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" || true)"
 
 if [[ "${TFENV_VERSION}" =~ ^latest.*$ ]]; then
   [[ "${TFENV_VERSION}" =~ ^latest\:.*$ ]] && regex="${TFENV_VERSION##*\:}"
@@ -22,20 +22,20 @@ if [[ "${TFENV_VERSION}" =~ ^latest.*$ ]]; then
     | grep -e "${regex}" \
     | head -n 1
   )"
-  [ -n "${version}" ] || error_and_die "'latest' version requested, but no installed versions matched"
+  [ -n "${version}" ] || error_and_die "No installed versions of terraform matched '${TFENV_VERSION}'"
   TFENV_VERSION="${version}"
 fi
 
-[ -z "$TFENV_VERSION" ] \
-  && error_and_die "Version could not be resolved (set by $TFENV_VERSION_FILE or tfenv use <version>)"
+[ -z "${TFENV_VERSION}" ] \
+  && error_and_die "Version could not be resolved (set by ${TFENV_VERSION_FILE} or tfenv use <version>)"
 
 version_exists() {
-  local version="$1"
+  local version="${1}"
   [ -d "${TFENV_ROOT}/versions/${version}" ]
 }
 
-if version_exists "$TFENV_VERSION"; then
-  echo "$TFENV_VERSION"
+if version_exists "${TFENV_VERSION}"; then
+  echo "${TFENV_VERSION}"
 else
-  error_and_die "version \`$TFENV_VERSION' is not installed (set by $TFENV_VERSION_FILE)"
+  error_and_die "version \`${TFENV_VERSION}' is not installed (set by ${TFENV_VERSION_FILE})"
 fi

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -1,15 +1,33 @@
 #!/usr/bin/env bash
 # Summary: Show the current Terraform version
 set -e
+
+function error_and_die() {
+  echo -e "tfenv: ${0}: ${1}" >&2
+  exit 1
+}
+
 [ -n "$TFENV_DEBUG" ] && set -x
+
+[ -d "${TFENV_ROOT}/versions" ] \
+  || error_and_die "No versions of terraform installed. Please install one with: tfenv install"
 
 TFENV_VERSION_FILE="$(tfenv-version-file)"
 TFENV_VERSION="$(cat "$TFENV_VERSION_FILE" || true)"
 
-if [ -z "$TFENV_VERSION" ]; then
-  echo "tfenv: version could not be resolved (set by $TFENV_VERSION_FILE or tfenv use <version>)" >&2
-  exit 1
+if [[ "${TFENV_VERSION}" =~ ^latest.*$ ]]; then
+  [[ "${TFENV_VERSION}" =~ ^latest\:.*$ ]] && regex="${TFENV_VERSION##*\:}"
+  version="$(\ls "${TFENV_ROOT}/versions" \
+    | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
+    | grep -e "${regex}" \
+    | head -n 1
+  )"
+  [ -n "${version}" ] || error_and_die "'latest' version requested, but no installed versions matched"
+  TFENV_VERSION="${version}"
 fi
+
+[ -z "$TFENV_VERSION" ] \
+  && error_and_die "Version could not be resolved (set by $TFENV_VERSION_FILE or tfenv use <version>)"
 
 version_exists() {
   local version="$1"
@@ -19,6 +37,5 @@ version_exists() {
 if version_exists "$TFENV_VERSION"; then
   echo "$TFENV_VERSION"
 else
-  echo "tfenv: version \`$TFENV_VERSION' is not installed (set by $TFENV_VERSION_FILE)" >&2
-  exit 1
+  error_and_die "version \`$TFENV_VERSION' is not installed (set by $TFENV_VERSION_FILE)"
 fi

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 check_version() {
-  v=${1}
+  v="${1}"
   [ -n "$(terraform --version | grep "Terraform v${v}")" ]
 }
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,25 +1,30 @@
 #!/usr/bin/env bash
 
-if [ -n "$TFENV_DEBUG" ]; then
+if [ -n "${TFENV_DEBUG}" ]; then
   export PS4='+ [${BASH_SOURCE##*/}:${LINENO}] '
   set -x
 fi
-TFENV_ROOT=$(cd $(dirname $0)/.. && pwd)
+TFENV_ROOT=$(cd $(dirname ${0})/.. && pwd)
 export PATH="${TFENV_ROOT}/bin:${PATH}"
 
 errors=()
-if [ $# -ne 0 ];then
-  targets="$@"
+if [ ${#} -ne 0 ];then
+  targets="${@}"
 else
-  targets=`ls $(dirname $0) | grep 'test_'`
+  targets=$(\ls $(dirname ${0}) | grep 'test_')
 fi
 
 for t in ${targets}; do
-  bash $(dirname $0)/${t} || errors+=( ${t} )
+  bash $(dirname ${0})/${t} || errors+=( ${t} )
 done
 
 if [ ${#errors[@]} -ne 0 ];then
-  echo -e "\033[0;31m===== Following tests failed ====\033[0;39m" 1>&2
-  echo "${errors[@]}"
+  echo -e "\033[0;31m===== The following test suites failed =====\033[0;39m" >&2
+  for error in "${errors[@]}"; do
+    echo -e "\t${error}" >&2
+  done
   exit 1
+else
+  echo -e "\033[0;32mAll test suites passed.\033[0;39m"
 fi
+exit 0

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -14,6 +14,17 @@ if ! check_version ${v}; then
   exit 1
 fi
 
+echo "### Install latest version with Regex"
+cleanup
+
+v=$(tfenv list-remote | grep 0.8 | head -n 1)
+tfenv install latest:^0.8
+tfenv use latest:^0.8
+if ! check_version ${v}; then
+  echo "Installing latest version ${v} with Regex" 1>&2
+  exit 1
+fi
+
 echo "### Install specific version"
 cleanup
 

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -1,58 +1,94 @@
 #!/usr/bin/env bash
 
+declare -a errors
+
+function error_and_proceed() {
+  errors+=("${1}")
+  echo -e "tfenv: ${0}: Test Failed: ${1}" >&2
+}
+
+function error_and_die() {
+  echo -e "tfenv: ${0}: ${1}" >&2
+  exit 1
+}
+
 [ -n "$TFENV_DEBUG" ] && set -x
-source $(dirname $0)/helpers.sh
+source $(dirname $0)/helpers.sh \
+  || error_and_die "Failed to load test helpers: $(dirname $0)/helpers.sh"
 
 echo "### Install latest version"
-cleanup
+cleanup || error_and_die "Cleanup failed?!"
 
 v=$(tfenv list-remote | head -n 1)
-tfenv install latest
-tfenv use ${v}
-if ! check_version ${v}; then
-  echo "Installing latest version ${v}" 1>&2
-  exit 1
-fi
+(
+  tfenv install latest || exit 1
+  tfenv use ${v} || exit 1
+  check_version ${v} || exit 1
+) || error_and_proceed "Installing latest version ${v}"
 
 echo "### Install latest version with Regex"
-cleanup
+cleanup || error_and_die "Cleanup failed?!"
 
 v=$(tfenv list-remote | grep 0.8 | head -n 1)
-tfenv install latest:^0.8
-tfenv use latest:^0.8
-if ! check_version ${v}; then
-  echo "Installing latest version ${v} with Regex" 1>&2
-  exit 1
-fi
+(
+  tfenv install latest:^0.8 || exit 1
+  tfenv use latest:^0.8 || exit 1
+  check_version ${v} || exit 1
+) || error_and_proceed "Installing latest version ${v} with Regex"
 
 echo "### Install specific version"
-cleanup
+cleanup || error_and_die "Cleanup failed?!"
 
 v=0.7.13
-tfenv install ${v}
-tfenv use ${v}
-if ! check_version ${v}; then
-  echo "Installing specific version ${v} failed" 1>&2
-  exit 1
-fi
+(
+  tfenv install ${v} || exit 1
+  tfenv use ${v} || exit 1
+  check_version ${v} || exit 1
+) || error_and_proceed "Installing specific version ${v}"
 
-echo "### Install .terraform-version"
-cleanup
+echo "### Install specific .terraform-version"
+cleanup || error_and_die "Cleanup failed?!"
 
 v=0.8.8
 echo ${v} > ./.terraform-version
-tfenv install
-if ! check_version ${v}; then
-  echo "Installing .terraform-version ${v}" 1>&2
-  exit 1
-fi
+(
+  tfenv install || exit 1
+  check_version ${v} || exit 1
+) || error_and_proceed "Installing .terraform-version ${v}"
 
-echo "### Install invalid version"
-cleanup
+echo "### Install latest:<regex> .terraform-version"
+cleanup || error_and_die "Cleanup failed?!"
+
+v=$(tfenv list-remote | grep -e '^0.8' | head -n 1)
+echo "latest:^0.8" > ./.terraform-version
+(
+  tfenv install || exit 1
+  check_version ${v} || exit 1
+) || error_and_proceed "Installing .terraform-version ${v}" 
+
+echo "### Install invalid specific version"
+cleanup || error_and_die "Cleanup failed?!"
 
 v=9.9.9
-expected_error_message="'${v}' doesn't exist in remote, please confirm version name."
-if [ -z "$(tfenv install ${v} 2>&1 | grep "${expected_error_message}")" ]; then
-  echo "Installing invalid version ${v}" 1>&2
+expected_error_message="No versions matching '${v}' found in remote"
+[ -z "$(tfenv install ${v} 2>&1 | grep "${expected_error_message}")" ] \
+  && error_and_proceed "Installing invalid version ${v}"
+
+echo "### Install invalid latest:<regex> version"
+cleanup || error_and_die "Cleanup failed?!"
+
+v="latest:word"
+expected_error_message="No versions matching '${v}' found in remote"
+[ -z "$(tfenv install ${v} 2>&1 | grep "${expected_error_message}")" ] \
+  && error_and_proceed "Installing invalid version ${v}"
+
+if [ ${#errors[@]} -gt 0 ]; then
+  echo -e "\033[0;31m===== The following install_and_use tests failed =====\033[0;39m" >&2
+  for error in "${errors[@]}"; do
+    echo -e "\t${error}"
+  done
   exit 1
-fi
+else
+  echo -e "\033[0;32mAll install_and_use tests passed.\033[0;39m"
+fi;
+exit 0

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -28,7 +28,7 @@ fi
 echo "### Install .terraform-version"
 cleanup
 
-v=0.6.15
+v=0.8.8
 echo ${v} > ./.terraform-version
 tfenv install
 if ! check_version ${v}; then
@@ -41,7 +41,7 @@ cleanup
 
 v=9.9.9
 expected_error_message="'${v}' doesn't exist in remote, please confirm version name."
-if [ -z "$(tfenv install ${v} | grep "${expected_error_message}")" ]; then
+if [ -z "$(tfenv install ${v} 2>&1 | grep "${expected_error_message}")" ]; then
   echo "Installing invalid version ${v}" 1>&2
   exit 1
 fi

--- a/test/test_symlink.sh
+++ b/test/test_symlink.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
 
-[ -n "$TFENV_DEBUG" ] && set -x
-source $(dirname $0)/helpers.sh
+declare -a errors
+
+function error_and_proceed() {
+  errors+=("${1}")
+  echo -e "tfenv: Test Failed: ${1}" >&2
+}
+
+function error_and_die() {
+  echo -e "tfenv: ${1}" >&2
+  exit 1
+}
+
+[ -n "${TFENV_DEBUG}" ] && set -x
+source $(dirname $0)/helpers.sh \
+  || error_and_die "Failed to load test helpers: $(dirname $0)/helpers.sh"
 
 TFENV_BIN_DIR=/tmp/tfenv-test
 rm -rf ${TFENV_BIN_DIR} && mkdir ${TFENV_BIN_DIR}
@@ -9,7 +22,18 @@ ln -s ${PWD}/bin/* ${TFENV_BIN_DIR}
 export PATH="${TFENV_BIN_DIR}:${PATH}"
 
 echo "### Test supporting symlink"
-cleanup
-tfenv install 0.8.2
-tfenv use 0.8.2
-check_version 0.8.2
+cleanup || error_and_die "Cleanup failed?!"
+tfenv install 0.8.2 || error_and_proceed "Install failed"
+tfenv use 0.8.2 || error_and_proceed "Use failed"
+check_version 0.8.2 || error_and_proceed "Version check failed"
+
+if [ ${#errors[@]} -gt 0 ]; then
+  echo -e "\033[0;31m===== The following symlink tests failed =====\033[0;39m" >&2
+  for error in "${errors[@]}"; do
+    echo -e "\t${error}"
+  done
+  exit 1
+else
+  echo -e "\033[0;32mAll symlink tests passed.\033[0;39m"
+fi;
+exit 0


### PR DESCRIPTION
README.md has been reverted to your version. I don't need to maintain a seperate version if you are taking PRs.

Have expanded the test suite slightly and reworked it to standardise it.

Added a CHANGELOG.md

Made sure tfenv-version-name can use "latest:<regex>" from .terraform-version

Other bash standardisation