### PR TITLE
prevent interactive prompting from keybase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.3 (April 11, 2017)
+
+ * Move temporary directory from /tmp to mktemp
+ * Upgrade tfenv-install logging
+
 ## 0.4.2 (April 9, 2017)
 
  * Add support for verifying downloads of Terraform

--- a/libexec/tfenv---version
+++ b/libexec/tfenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${TFENV_DEBUG}" ] && set -x
 
-version="0.4.2"
+version="0.4.3"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q tfenv; then

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -66,26 +66,29 @@ tarball_name="terraform_${version}_${os}.zip"
 shasums_name="terraform_${version}_SHA256SUMS"
 echo "Installing Terraform v${version}"
 echo "Downloading release tarball from ${version_url}/${tarball_name}"
-curl --tlsv1.2 -f -o /tmp/${tarball_name} "${version_url}/${tarball_name}" || error_and_die "Tarball download failed"
+TFENV_TEMP=$(mktemp -d tfenv-XXX)
+curl -s --tlsv1.2 -f -o ${TFENV_TEMP}/${tarball_name} "${version_url}/${tarball_name}" || error_and_die "Tarball download failed"
 echo "Downloading SHA hash file from ${version_url}/${sha256sums}"
-curl -s --tlsv1.2 -f -o /tmp/${shasums_name} "${version_url}/${shasums_name}" || error_and_die "SHA256 hashes download failed"
+curl -s --tlsv1.2 -f -o ${TFENV_TEMP}/${shasums_name} "${version_url}/${shasums_name}" || error_and_die "SHA256 hashes download failed"
 
 if [[ -n $keybase && -x "$keybase" ]]; then
   echo "Downloading SHA hash signature file from ${version_url}/${sha256sums}.sig"
-  curl -s --tlsv1.2 -f -o /tmp/${shasums_name}.sig "${version_url}/${shasums_name}.sig" || error_and_die "SHA256SUMS signature download failed"
-  ${keybase} pgp verify -S hashicorp -d "/tmp/${shasums_name}.sig" -i "/tmp/${shasums_name}" || error_and_die "SHA256SUMS signature does not match!"
+  curl -s --tlsv1.2 -f -o ${TFENV_TEMP}/${shasums_name}.sig "${version_url}/${shasums_name}.sig" || error_and_die "SHA256SUMS signature download failed"
+  ${keybase} pgp verify -S hashicorp -d "${TFENV_TEMP}/${shasums_name}.sig" -i "${TFENV_TEMP}/${shasums_name}" || error_and_die "SHA256SUMS signature does not match!"
 else
   echo "No keybase install found, skipping SHA hash file validation..."
 fi
 
 if [[ -n $shasum && -x $shasum ]]; then
   pushd /tmp >/dev/null
-  ${shasum} -a 256 -s -c <(fgrep ${tarball_name} /tmp/${shasums_name}) || error_and_die "SHA256 hash does not match!"
+  ${shasum} -a 256 -s -c <(fgrep ${tarball_name} ${TFENV_TEMP}/${shasums_name}) || error_and_die "SHA256 hash does not match!"
   popd >/dev/null
 else
   echo "No shasum tool for validating the SHA256 hash was found, skipping download validation..."
 fi
 
 mkdir -p ${dst_path} || error_and_die "Failed to make directory ${dst_path}"
-unzip /tmp/${tarball_name} -d ${dst_path} || error_and_die "Tarball unzip failed"
+unzip ${TFENV_TEMP}/${tarball_name} -d ${dst_path} || error_and_die "Tarball unzip failed"
 echo -e "\033[0;32mInstallation of terraform v${version} successful\033[0;39m"
+
+trap "rm -rf ${TFENV_TEMP}" EXIT;

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -15,7 +15,7 @@ function info() {
 
 [ -n "${TFENV_DEBUG}" ] && set -x
 
-[ ${#} -gt 1 ] && error_and_die "usage: tfenv install [<version>]"
+[ "${#}" -gt 1 ] && error_and_die "usage: tfenv install [<version>]"
 
 declare version_requested version regex
 
@@ -44,7 +44,7 @@ version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)"
 [ -n "${version}" ] || error_and_die "No versions matching '${1}' found in remote"
 
 dst_path="${TFENV_ROOT}/versions/${version}"
-if [ -f ${dst_path}/terraform ]; then
+if [ -f "${dst_path}/terraform" ]; then
   echo "Terraform v${version} is already installed"
   exit 0
 fi
@@ -76,23 +76,23 @@ download_tmp="$(mktemp -d tfenv_download.XXXXXX)" || error_and_die "Unable to cr
 trap 'rm -rf "${download_tmp}"' EXIT;
 
 info "Downloading release tarball from ${version_url}/${tarball_name}"
-curl -s --tlsv1.2 -f -o ${download_tmp}/${tarball_name} "${version_url}/${tarball_name}" || error_and_die "Tarball download failed"
+curl -s --tlsv1.2 -f -o "${download_tmp}/${tarball_name}" "${version_url}/${tarball_name}" || error_and_die "Tarball download failed"
 info "Downloading SHA hash file from ${version_url}/${shasums_name}"
-curl -s --tlsv1.2 -f -o ${download_tmp}/${shasums_name} "${version_url}/${shasums_name}" || error_and_die "SHA256 hashes download failed"
+curl -s --tlsv1.2 -f -o "${download_tmp}/${shasums_name}" "${version_url}/${shasums_name}" || error_and_die "SHA256 hashes download failed"
 
 # Verify signature if keybase is present.
 if [[ -n "${keybase_bin}" && -x "${keybase_bin}" ]]; then
-  $keybase_bin status | egrep -q '^Logged in:[[:space:]]*yes'
+  "${keybase_bin}" status | egrep -q '^Logged in:[[:space:]]*yes'
   keybase_logged_in=$?
-  $keybase_bin list-following | fgrep -q hashicorp
+  "${keybase_bin}" list-following | fgrep -q hashicorp
   keybase_following_hc=$?
 
-  if [[ $keybase_logged_in -ne 0 || $keybase_following_hc -ne 0 ]]; then
+  if [[ "${keybase_logged_in}" -ne 0 || "${keybase_following_hc}" -ne 0 ]]; then
     warn_and_continue "To verify the GPG signature on the hash file,\nmake sure you're logged into keybase and following hashicorp"
   else
     info "Downloading SHA hash signature file from ${version_url}/${shasums_name}.sig"
-    curl -s --tlsv1.2 -f -o ${download_tmp}/${shasums_name}.sig "${version_url}/${shasums_name}.sig" || error_and_die "SHA256SUMS signature download failed"
-    ${keybase_bin} pgp verify -S hashicorp -d "${download_tmp}/${shasums_name}.sig" -i "${download_tmp}/${shasums_name}" || error_and_die "SHA256SUMS signature does not match!"
+    curl -s --tlsv1.2 -f -o "${download_tmp}/${shasums_name}.sig" "${version_url}/${shasums_name}.sig" || error_and_die "SHA256SUMS signature download failed"
+    "${keybase_bin}" pgp verify -S hashicorp -d "${download_tmp}/${shasums_name}.sig" -i "${download_tmp}/${shasums_name}" || error_and_die "SHA256SUMS signature does not match!"
   fi
 else
   # Warning about this avoids an unwarranted sense of confidence in the SHA check
@@ -101,15 +101,15 @@ fi
 
 if [[ -n "${shasum_bin}" && -x "${shasum_bin}" ]]; then
   (
-    cd ${download_tmp}
-    ${shasum_bin} -a 256 -s -c <(fgrep ${tarball_name} ${shasums_name}) || error_and_die "SHA256 hash does not match!"
+    cd "${download_tmp}"
+    "${shasum_bin}" -a 256 -s -c <(fgrep "${tarball_name}" "${shasums_name}") || error_and_die "SHA256 hash does not match!"
   )
 else
   # Lack of shasum deserves a proper warning
   warn_and_continue "No shasum tool available. Skipping SHA256 hash validation"
 fi
 
-mkdir -p ${dst_path} || error_and_die "Failed to make directory ${dst_path}"
-unzip ${download_tmp}/${tarball_name} -d ${dst_path} || error_and_die "Tarball unzip failed"
+mkdir -p "${dst_path}" || error_and_die "Failed to make directory ${dst_path}"
+unzip "${download_tmp}/${tarball_name}" -d "${dst_path}" || error_and_die "Tarball unzip failed"
 
 info "Installation of terraform v${version} successful"

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 function error_and_die() {
-  echo -e "tfenv: ${0}: [\033[0;31mERROR] ${1}\033[0;39m" >&2
+  echo -e "tfenv: $(basename ${0}): [\033[0;31mERROR] ${1}\033[0;39m" >&2
   exit 1
 }
 
 function warn_and_continue() {
-  echo -e "tfenv: ${0}: \033[0;33m[WARN] ${1}\033[0;39m" >&2
+  echo -e "tfenv: $(basename ${0}): \033[0;33m[WARN] ${1}\033[0;39m" >&2
 }
 
 function info() {

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 
 function error_and_die() {
-  echo -e "tfenv: ${0}: ${1}" >&2
+  echo -e "tfenv: ${0}: [\033[0;31mERROR] ${1}\033[0;39m" >&2
   exit 1
+}
+
+function warn_and_continue() {
+  echo -e "tfenv: ${0}: \033[0;33m[WARN] ${1}\033[0;39m" >&2
+}
+
+function info() {
+  echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
 }
 
 [ -n "${TFENV_DEBUG}" ] && set -x
@@ -42,53 +50,60 @@ if [ -f ${dst_path}/terraform ]; then
 fi
 
 case "$(uname -s)" in
-Darwin* )
-  os="darwin_amd64"
-  ;;
-MINGW64* )
-  os="windows_amd64"
-  ;;
-* )
-  os="linux_amd64"
+  Darwin*)
+    os="darwin_amd64"
+    ;;
+  MINGW64*)
+    os="windows_amd64"
+    ;;
+  *)
+    os="linux_amd64"
+    ;;
 esac
 
-keybase=$(which keybase)
-shasum=$(which shasum)
-
+keybase_bin="$(which keybase)"
+shasum_bin="$(which shasum)"
 if [[ -n $keybase && -x "$keybase" ]]; then
+  info "Keybase install detected; using keybase to verify download signature"
   if ! $keybase list-following | fgrep -q hashicorp; then
-    echo "NOTICE: Following 'hashicorp' with keybase will make this process smoother."
+    info "Following 'hashicorp' with keybase will make this process smoother"
   fi
 fi
 
 version_url="https://releases.hashicorp.com/terraform/${version}"
 tarball_name="terraform_${version}_${os}.zip"
 shasums_name="terraform_${version}_SHA256SUMS"
-echo "Installing Terraform v${version}"
-echo "Downloading release tarball from ${version_url}/${tarball_name}"
-TFENV_TEMP=$(mktemp -d tfenv-XXX)
-curl -s --tlsv1.2 -f -o ${TFENV_TEMP}/${tarball_name} "${version_url}/${tarball_name}" || error_and_die "Tarball download failed"
-echo "Downloading SHA hash file from ${version_url}/${sha256sums}"
-curl -s --tlsv1.2 -f -o ${TFENV_TEMP}/${shasums_name} "${version_url}/${shasums_name}" || error_and_die "SHA256 hashes download failed"
 
-if [[ -n $keybase && -x "$keybase" ]]; then
-  echo "Downloading SHA hash signature file from ${version_url}/${sha256sums}.sig"
-  curl -s --tlsv1.2 -f -o ${TFENV_TEMP}/${shasums_name}.sig "${version_url}/${shasums_name}.sig" || error_and_die "SHA256SUMS signature download failed"
-  ${keybase} pgp verify -S hashicorp -d "${TFENV_TEMP}/${shasums_name}.sig" -i "${TFENV_TEMP}/${shasums_name}" || error_and_die "SHA256SUMS signature does not match!"
-else
-  echo "No keybase install found, skipping SHA hash file validation..."
+info "Installing Terraform v${version}"
+
+# Create a local temporary directory for downloads
+download_tmp="$(mktemp -d download.XXXXXX)" || error_and_die "Unable to create temporary download directory in $(pwd)"
+# Clean it up in case of error
+trap "rm -rf ${download_tmp}" EXIT;
+
+info "Downloading release tarball from ${version_url}/${tarball_name}"
+curl -s --tlsv1.2 -f -o ${download_tmp}/${tarball_name} "${version_url}/${tarball_name}" || error_and_die "Tarball download failed"
+info "Downloading SHA hash file from ${version_url}/${shasums_name}"
+curl -s --tlsv1.2 -f -o ${download_tmp}/${shasums_name} "${version_url}/${shasums_name}" || error_and_die "SHA256 hashes download failed"
+
+# Verify signature if keybase is present.
+if [[ -n "${keybase_bin}" && -x "${keybase_bin}" ]]; then
+  info "Downloading SHA hash signature file from ${version_url}/${shasums_name}.sig"
+  curl -s --tlsv1.2 -f -o ${download_tmp}/${shasums_name}.sig "${version_url}/${shasums_name}.sig" || error_and_die "SHA256SUMS signature download failed"
+  ${keybase_bin} pgp verify -S hashicorp -d "${download_tmp}/${shasums_name}.sig" -i "${download_tmp}/${shasums_name}" || error_and_die "SHA256SUMS signature does not match!"
 fi
 
-if [[ -n $shasum && -x $shasum ]]; then
-  pushd /tmp >/dev/null
-  ${shasum} -a 256 -s -c <(fgrep ${tarball_name} ${TFENV_TEMP}/${shasums_name}) || error_and_die "SHA256 hash does not match!"
-  popd >/dev/null
+if [[ -n "${shasum_bin}" && -x "${shasum_bin}" ]]; then
+  (
+    cd ${download_tmp}
+    ${shasum_bin} -a 256 -s -c <(fgrep ${tarball_name} ${shasums_name}) || error_and_die "SHA256 hash does not match!"
+  )
 else
-  echo "No shasum tool for validating the SHA256 hash was found, skipping download validation..."
+  # Lack of shasum deserves a proper warning
+  warn_and_continue "No shasum tool available. Skipping SHA256 hash validation"
 fi
 
 mkdir -p ${dst_path} || error_and_die "Failed to make directory ${dst_path}"
-unzip ${TFENV_TEMP}/${tarball_name} -d ${dst_path} || error_and_die "Tarball unzip failed"
-echo -e "\033[0;32mInstallation of terraform v${version} successful\033[0;39m"
+unzip ${download_tmp}/${tarball_name} -d ${dst_path} || error_and_die "Tarball unzip failed"
 
-trap "rm -rf ${TFENV_TEMP}" EXIT;
+info "Installation of terraform v${version} successful"

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -61,14 +61,8 @@ case "$(uname -s)" in
     ;;
 esac
 
-keybase_bin="$(which keybase)"
-shasum_bin="$(which shasum)"
-if [[ -n $keybase && -x "$keybase" ]]; then
-  info "Keybase install detected; using keybase to verify download signature"
-  if ! $keybase list-following | fgrep -q hashicorp; then
-    info "Following 'hashicorp' with keybase will make this process smoother"
-  fi
-fi
+keybase_bin=$(which keybase)
+shasum_bin=$(which shasum)
 
 version_url="https://releases.hashicorp.com/terraform/${version}"
 tarball_name="terraform_${version}_${os}.zip"
@@ -77,9 +71,9 @@ shasums_name="terraform_${version}_SHA256SUMS"
 info "Installing Terraform v${version}"
 
 # Create a local temporary directory for downloads
-download_tmp="$(mktemp -d download.XXXXXX)" || error_and_die "Unable to create temporary download directory in $(pwd)"
+download_tmp="$(mktemp -d tfenv_download.XXXXXX)" || error_and_die "Unable to create temporary download directory in $(pwd)"
 # Clean it up in case of error
-trap "rm -rf ${download_tmp}" EXIT;
+trap 'rm -rf "${download_tmp}"' EXIT;
 
 info "Downloading release tarball from ${version_url}/${tarball_name}"
 curl -s --tlsv1.2 -f -o ${download_tmp}/${tarball_name} "${version_url}/${tarball_name}" || error_and_die "Tarball download failed"
@@ -88,9 +82,21 @@ curl -s --tlsv1.2 -f -o ${download_tmp}/${shasums_name} "${version_url}/${shasum
 
 # Verify signature if keybase is present.
 if [[ -n "${keybase_bin}" && -x "${keybase_bin}" ]]; then
-  info "Downloading SHA hash signature file from ${version_url}/${shasums_name}.sig"
-  curl -s --tlsv1.2 -f -o ${download_tmp}/${shasums_name}.sig "${version_url}/${shasums_name}.sig" || error_and_die "SHA256SUMS signature download failed"
-  ${keybase_bin} pgp verify -S hashicorp -d "${download_tmp}/${shasums_name}.sig" -i "${download_tmp}/${shasums_name}" || error_and_die "SHA256SUMS signature does not match!"
+  $keybase_bin status | egrep -q '^Logged in:[[:space:]]*yes'
+  keybase_logged_in=$?
+  $keybase_bin list-following | fgrep -q hashicorp
+  keybase_following_hc=$?
+
+  if [[ $keybase_logged_in -ne 0 || $keybase_following_hc -ne 0 ]]; then
+    warn_and_continue "To verify the GPG signature on the hash file,\nmake sure you're logged into keybase and following hashicorp"
+  else
+    info "Downloading SHA hash signature file from ${version_url}/${shasums_name}.sig"
+    curl -s --tlsv1.2 -f -o ${download_tmp}/${shasums_name}.sig "${version_url}/${shasums_name}.sig" || error_and_die "SHA256SUMS signature download failed"
+    ${keybase_bin} pgp verify -S hashicorp -d "${download_tmp}/${shasums_name}.sig" -i "${download_tmp}/${shasums_name}" || error_and_die "SHA256SUMS signature does not match!"
+  fi
+else
+  # Warning about this avoids an unwarranted sense of confidence in the SHA check
+  warn_and_continue "No keybase install found, skipping GPG signature verification"
 fi
 
 if [[ -n "${shasum_bin}" && -x "${shasum_bin}" ]]; then


### PR DESCRIPTION
This changes up the process a little to test to make sure
that the user is logged into keybase before trying to use
it. If logged in, it also verifies that they are following
hashicorp before trying to validate.

To call a bit more attention when key aspects are missing
it now highlights those relevant messages in yellow.