### PR TITLE
Fix and unit test for uninstall latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,12 @@ $ tfenv use latest:^0.8
 
 ### tfenv uninstall
 Uninstall a specific version of Terraform
+`latest` is a syntax to uninstall latest version
+`latest:<regex>` is a syntax to uninstall latest version matching regex (used by grep -e)
 ```sh
-$ tfenv uninstall 0.9.0
+$ tfenv uninstall 0.7.0
+$ tfenv install latest
+$ tfenv install latest:^0.8
 ```
 
 ### tfenv list

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Uninstall a specific version of Terraform
 `latest:<regex>` is a syntax to uninstall latest version matching regex (used by grep -e)
 ```sh
 $ tfenv uninstall 0.7.0
-$ tfenv install latest
-$ tfenv install latest:^0.8
+$ tfenv uninstall latest
+$ tfenv uninstall latest:^0.8
 ```
 
 ### tfenv list

--- a/libexec/tfenv-uninstall
+++ b/libexec/tfenv-uninstall
@@ -36,7 +36,7 @@ else
 fi
 
 [ -n "${version}" ] || error_and_die "Version is not specified"
-version="$(tfenv-list | grep -e "${regex}" )"
+version="$(tfenv-list | grep -e "${regex}" | head -n 1)"
 [ -n "${version}" ] || error_and_die "No versions matching '${1}' found in local"
 
 dst_path="${TFENV_ROOT}/versions/${version}"

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -36,17 +36,6 @@ v=$(tfenv list-remote | grep 0.8 | head -n 1)
   check_version ${v} || exit 1
 ) || error_and_proceed "Installing latest version ${v} with Regex"
 
-echo "### Install latest version with Regex"
-cleanup
-
-v=$(tfenv list-remote | grep 0.8 | head -n 1)
-tfenv install latest:^0.8
-tfenv use latest:^0.8
-if ! check_version ${v}; then
-  echo "Installing latest version ${v} with Regex" 1>&2
-  exit 1
-fi
-
 echo "### Install specific version"
 cleanup || error_and_die "Cleanup failed?!"
 

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -26,6 +26,26 @@ v=0.1.0
   tfenv list | grep 0.1.0 && exit 1 || exit 0
 ) || error_and_proceed "Uninstall of version ${v} failed"
 
+echo "### Uninstall latest version"
+cleanup || error_and_die "Cleanup failed?!"
+
+v=$(tfenv list-remote | head -n 1)
+(
+  tfenv install latest || exit 1
+  tfenv uninstall latest || exit 1
+  tfenv list | grep ${v} && exit 1 || exit 0
+) || error_and_proceed "Uninstalling latest version ${v}"
+
+echo "### Uninstall latest version with Regex"
+cleanup || error_and_die "Cleanup failed?!"
+
+v=$(tfenv list-remote | grep 0.8 | head -n 1)
+(
+  tfenv install latest:^0.8 || exit 1
+  tfenv uninstall latest:^0.8 || exit 1
+  tfenv list | grep ${v} && exit 1 || exit 0
+) || error_and_proceed "Uninstalling latest version ${v} with Regex"
+
 if [ ${#errors[@]} -gt 0 ]; then
   echo -e "\033[0;31m===== The following list tests failed =====\033[0;39m" >&2
   for error in "${errors[@]}"; do


### PR DESCRIPTION
Here are the unit tests for uninstall latest and uninstall latest:^x.x.x.
I think I have found duplicate code in test_install_and_use.sh : "Install latest version with Regex" is present twice. 
Do you want another pull request for this?

```
echo "### Install latest version with Regex"
cleanup || error_and_die "Cleanup failed?!"

v=$(tfenv list-remote | grep 0.8 | head -n 1)
(
  tfenv install latest:^0.8 || exit 1
  tfenv use latest:^0.8 || exit 1
  check_version ${v} || exit 1
) || error_and_proceed "Installing latest version ${v} with Regex"

echo "### Install latest version with Regex"
cleanup

v=$(tfenv list-remote | grep 0.8 | head -n 1)
tfenv install latest:^0.8
tfenv use latest:^0.8
if ! check_version ${v}; then
  echo "Installing latest version ${v} with Regex" 1>&2
  exit 1
fi
```