### PR TITLE
Immediately switch version after installation

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -113,3 +113,4 @@ mkdir -p "${dst_path}" || error_and_die "Failed to make directory ${dst_path}"
 unzip "${download_tmp}/${tarball_name}" -d "${dst_path}" || error_and_die "Tarball unzip failed"
 
 info "Installation of terraform v${version} successful"
+tfenv-use "$version"

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -5,6 +5,10 @@ function error_and_die() {
   exit 1
 }
 
+function info() {
+  echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
+}
+
 [ -n "${TFENV_DEBUG}" ] && set -x
 
 [ ${#} -ne 1 ] && error_and_die "usage: tfenv use <version>"
@@ -41,5 +45,7 @@ target_path=${TFENV_ROOT}/versions/${version}
 [ -x ${target_path}/terraform ] \
   || error_and_die "Version directory for ${version} is present, but the terraform binary is not executable! Manual intervention required. "
 
+info "Switching to v${version}"
 echo "${version}" > "${TFENV_ROOT}/version"
-terraform --version || error_and_die "'terraform --version' failed. Something is seriously wrong"
+terraform --version 1>/dev/null || error_and_die "'terraform --version' failed. Something is seriously wrong"
+info "Switching completed"


### PR DESCRIPTION
Switch the version by default after an installation :satellite:

**Reasons**
* For new installations does not make sense to `tfenv use`
* I find myself having to install new versions and then switching to that version every time
* Switching only becomes relevant when at least two versions are installed
* Reduce manual steps :bowtie: