### PR TITLE
Switch TLS option for curl depending on the version of macOS

### DIFF
--- a/libexec/helpers
+++ b/libexec/helpers
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+function error_and_die() {
+  echo -e "tfenv: $(basename ${0}): \033[0;31m[ERROR] ${1}\033[0;39m" >&2
+  exit 1
+}
+
+function warn_and_continue() {
+  echo -e "tfenv: $(basename ${0}): \033[0;33m[WARN] ${1}\033[0;39m" >&2
+}
+
+function info() {
+  echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
+}

--- a/libexec/helpers
+++ b/libexec/helpers
@@ -12,3 +12,15 @@ function warn_and_continue() {
 function info() {
   echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
 }
+
+# Curl wrapper to switch TLS option for each OS
+function curlw () {
+  local TLS_OPT="--tlsv1.2"
+
+  # Check if curl is 10.12.6 or above
+  if [[ -n "$(which sw_vers 2>/dev/null)" && "$(sw_vers)" =~ 10\.12\.([6-9]|[0-9]{2}) ]]; then
+    TLS_OPT=""
+  fi
+
+  curl ${TLS_OPT} "$@"
+}

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -1,19 +1,7 @@
 #!/usr/bin/env bash
 
-function error_and_die() {
-  echo -e "tfenv: $(basename ${0}): \033[0;31m[ERROR] ${1}\033[0;39m" >&2
-  exit 1
-}
-
-function warn_and_continue() {
-  echo -e "tfenv: $(basename ${0}): \033[0;33m[WARN] ${1}\033[0;39m" >&2
-}
-
-function info() {
-  echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
-}
-
 [ -n "${TFENV_DEBUG}" ] && set -x
+source ${TFENV_ROOT}/libexec/helpers
 
 [ "${#}" -gt 1 ] && error_and_die "usage: tfenv install [<version>]"
 

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -65,9 +65,9 @@ download_tmp="$(mktemp -d tfenv_download.XXXXXX)" || error_and_die "Unable to cr
 trap "rm -rf ${download_tmp}" EXIT;
 
 info "Downloading release tarball from ${version_url}/${tarball_name}"
-curl -# --tlsv1.2 -f -o "${download_tmp}/${tarball_name}" "${version_url}/${tarball_name}" || error_and_die "Tarball download failed"
+curlw -# -f -o "${download_tmp}/${tarball_name}" "${version_url}/${tarball_name}" || error_and_die "Tarball download failed"
 info "Downloading SHA hash file from ${version_url}/${shasums_name}"
-curl -s --tlsv1.2 -f -o "${download_tmp}/${shasums_name}" "${version_url}/${shasums_name}" || error_and_die "SHA256 hashes download failed"
+curlw -s -f -o "${download_tmp}/${shasums_name}" "${version_url}/${shasums_name}" || error_and_die "SHA256 hashes download failed"
 
 # Verify signature if keybase is present.
 if [[ -n "${keybase_bin}" && -x "${keybase_bin}" ]]; then
@@ -80,7 +80,7 @@ if [[ -n "${keybase_bin}" && -x "${keybase_bin}" ]]; then
     warn_and_continue "Unable to verify GPG signature unless logged into keybase and following hashicorp"
   else
     info "Downloading SHA hash signature file from ${version_url}/${shasums_name}.sig"
-    curl -s --tlsv1.2 -f -o "${download_tmp}/${shasums_name}.sig" "${version_url}/${shasums_name}.sig" || error_and_die "SHA256SUMS signature download failed"
+    curlw -s -f -o "${download_tmp}/${shasums_name}.sig" "${version_url}/${shasums_name}.sig" || error_and_die "SHA256SUMS signature download failed"
     "${keybase_bin}" pgp verify -S hashicorp -d "${download_tmp}/${shasums_name}.sig" -i "${download_tmp}/${shasums_name}" || error_and_die "SHA256SUMS signature does not match!"
   fi
 else

--- a/libexec/tfenv-list
+++ b/libexec/tfenv-list
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 
-function error_and_die() {
-  echo -e "tfenv: ${0}: ${1}" >&2
-  exit 1
-}
-
 [ -n "${TFENV_DEBUG}" ] && set -x
+source ${TFENV_ROOT}/libexec/helpers
 
 [ ${#} -ne 0 ] \
   && error_and_die "usage: tfenv list"

--- a/libexec/tfenv-list-remote
+++ b/libexec/tfenv-list-remote
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -e
 [ -n "${TFENV_DEBUG}" ] && set -x
+source ${TFENV_ROOT}/libexec/helpers
 
 if [ ${#} -ne 0 ];then
   echo "usage: tfenv list-remote" 1>&2
   exit 1
 fi
 
-curl --tlsv1.2 -sf https://releases.hashicorp.com/terraform/ | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)?" | uniq
+curlw -sf https://releases.hashicorp.com/terraform/ | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)?" | uniq

--- a/libexec/tfenv-uninstall
+++ b/libexec/tfenv-uninstall
@@ -1,15 +1,7 @@
 #!/usr/bin/env bash
 
-function error_and_die() {
-  echo -e "tfenv: $(basename ${0}): \033[0;31m[ERROR] ${1}\033[0;39m" >&2
-  exit 1
-}
-
-function info() {
-  echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
-}
-
 [ -n "${TFENV_DEBUG}" ] && set -x
+source ${TFENV_ROOT}/libexec/helpers
 
 [ ${#} -gt 1 ] && error_and_die "usage: tfenv uninstall [<version>]"
 

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -1,15 +1,7 @@
 #!/usr/bin/env bash
 
-function error_and_die() {
-  echo -e "tfenv: ${0}: ${1}" >&2
-  exit 1
-}
-
-function info() {
-  echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
-}
-
 [ -n "${TFENV_DEBUG}" ] && set -x
+source ${TFENV_ROOT}/libexec/helpers
 
 [ ${#} -ne 1 ] && error_and_die "usage: tfenv use <version>"
 

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -2,12 +2,8 @@
 # Summary: Show the current Terraform version
 set -e
 
-function error_and_die() {
-  echo -e "tfenv: ${0}: ${1}" >&2
-  exit 1
-}
-
 [ -n "${TFENV_DEBUG}" ] && set -x
+source ${TFENV_ROOT}/libexec/helpers
 
 [ -d "${TFENV_ROOT}/versions" ] \
   || error_and_die "No versions of terraform installed. Please install one with: tfenv install"


### PR DESCRIPTION
For #60.
For some reason, `curl --tlsv1.2` doesn't work with macOS 10.12.6 and curl 7.54.0
Additionally, in order to reuse the logic of version checking in some scripts, added a helper file.