### PR TITLE
Force tfenv from same directory

### DIFF
--- a/bin/terraform
+++ b/bin/terraform
@@ -3,4 +3,4 @@ set -e
 [ -n "$TFENV_DEBUG" ] && set -x
 
 program="${0##*/}"
-exec tfenv exec "$@"
+exec "$(dirname `which $0`)"/tfenv exec "$@"

--- a/libexec/tfenv-version-file
+++ b/libexec/tfenv-version-file
@@ -7,6 +7,15 @@ set -e
 find_local_version_file() {
   local root="${1}"
   while ! [[ "${root}" =~ ^//[^/]*$ ]]; do
+
+    if [ -e "${root}/backend.tf" ]; then
+      version=$(grep required_version "${root}"/backend.tf | tr -dcs '0-9.' '')
+
+      if [[ ! -z "$version" ]]; then
+        echo "$version" > "${root}/.terraform-version"
+      fi
+    fi
+
     if [ -e "${root}/.terraform-version" ]; then
       echo "${root}/.terraform-version"
       return 0


### PR DESCRIPTION
For some reason vscode was complaining that tfenv is not found when running our little proxy terraform