### PR TITLE
Support msys2 bash.exe

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -45,6 +45,9 @@ case "$(uname -s)" in
   MINGW64*)
     os="windows_${TFENV_ARCH}"
     ;;
+  MSYS_NT*)
+    os="windows_${TFENV_ARCH}"
+    ;;
   *)
     os="linux_${TFENV_ARCH}"
     ;;


### PR DESCRIPTION
[msys2 bash](http://www.msys2.org/) didn't work for me. This patch results in great success:

```
Pete@petermounce MSYS ~
$ uname -s
MSYS_NT-10.0-WOW

Pete@petermounce MSYS ~
$ tfenv install 0.10.8
[INFO] Installing Terraform v0.10.8
[INFO] Downloading release tarball from https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_windows_amd64.zip
######################################################################## 100.0%
[INFO] Downloading SHA hash file from https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_SHA256SUMS
tfenv: tfenv-install: [WARN] No keybase install found, skipping GPG signature verification
Archive:  tfenv_download.Q2rM0S/terraform_0.10.8_windows_amd64.zip
  inflating: /c/Users/Pete/.tfenv/versions/0.10.8/terraform.exe
[INFO] Installation of terraform v0.10.8 successful
[INFO] Switching to v0.10.8
[INFO] Switching completed

Pete@petermounce MSYS ~
$ terraform --version
Terraform v0.10.8
```